### PR TITLE
feat: Add feature to fetch and annotate text from a URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,11 @@
             <button id="edit-btn">Edit Text</button>
         </header>
 
+        <div class="url-fetch-container">
+            <input type="text" id="url-input" placeholder="Enter URL to fetch text...">
+            <button id="fetch-btn">Fetch & Annotate</button>
+        </div>
+
         <div class="sidebar">
             <h2>Sample Pages</h2>
             <ul id="page-list">
@@ -57,6 +62,7 @@
         </div>
     </div>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/readability/0.5.0/Readability.min.js" integrity="sha512-d1b/I0324Uo2oBscD/00J2EXKGIhsKUpKASi+U2sSI088n76J306sgDsyWH9rLg6YlYx8sRihKOBIO+p5yQ3SQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const pageList = document.getElementById('page-list');
     const textContentDiv = document.getElementById('text-content');
     const editBtn = document.getElementById('edit-btn');
+    const urlInput = document.getElementById('url-input');
+    const fetchBtn = document.getElementById('fetch-btn');
     const colorPaletteToolbar = document.querySelector('.toolbar'); // Get the toolbar
     const colorBtns = document.querySelectorAll('.color-btn');
 
@@ -488,6 +490,75 @@ document.addEventListener('DOMContentLoaded', () => {
             closeModal(commentModal);
         }
     };
+
+    // --- URL Fetching ---
+    async function fetchAndDisplayArticle() {
+        const url = urlInput.value.trim();
+        if (!url) {
+            alert('Please enter a URL.');
+            return;
+        }
+
+        // Simple validation for URL format
+        try {
+            new URL(url);
+        } catch (_) {
+            alert('Please enter a valid URL.');
+            return;
+        }
+
+        const proxyUrl = `https://proxy.corsfix.com/?${encodeURIComponent(url)}`;
+
+        // Give user feedback that something is happening
+        fetchBtn.textContent = 'Fetching...';
+        fetchBtn.disabled = true;
+
+        try {
+            const response = await fetch(proxyUrl);
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const html = await response.text();
+
+            // Note: Readability modifies the DOM it's given.
+            // To avoid messing up the current page's DOM, we parse the fetched HTML
+            // into a new document.
+            const doc = new DOMParser().parseFromString(html, 'text/html');
+
+            // We also need to set the document's URL for Readability to resolve relative links correctly.
+            // Although we don't display images/links from the article, it's good practice.
+            doc.baseURI = url;
+
+            const reader = new Readability(doc);
+            const article = reader.parse();
+
+            if (article && article.content) {
+                const newPageId = `page-${Date.now()}`;
+                pagesData[newPageId] = {
+                    title: article.title || 'Untitled Article',
+                    content: article.content,
+                    annotations: []
+                };
+                renderPageList();
+                loadPage(newPageId);
+                urlInput.value = ''; // Clear input
+            } else {
+                alert('Could not extract article content. Please try another URL.');
+            }
+        } catch (error) {
+            console.error('Error fetching or parsing article:', error);
+            alert('Failed to fetch or parse the article. See console for details.');
+        } finally {
+            // Restore button state
+            fetchBtn.textContent = 'Fetch & Annotate';
+            fetchBtn.disabled = false;
+        }
+    }
+
+    if(fetchBtn) {
+        fetchBtn.addEventListener('click', fetchAndDisplayArticle);
+    }
+
 
     // --- Initial Setup ---
     renderPageList();


### PR DESCRIPTION
This commit introduces a new feature that allows users to supply a URL, fetch the content of that URL, and have the main text body extracted for annotation.

Key changes:
- Adds a URL input field and a "Fetch & Annotate" button to `index.html`.
- Includes Mozilla's Readability.js library via a CDN to handle article extraction.
- Implements the fetching logic in `script.js`, using a free CORS proxy (`proxy.corsfix.com`) to bypass cross-origin issues.
- When a URL is fetched, the extracted article content is added as a new page in the application's sidebar, ready for annotation.
- Includes user feedback during the fetching process and basic error handling.